### PR TITLE
Remove useless line of code.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -34,7 +34,7 @@
   <!-- Test and build all files  -->
   <!-- To run this: use "ant" (default) or "ant run" -->
   <target name="run" depends="build">
-    <junit printsummary="on" haltonfailure="yes" failureProperty="test.failure">
+    <junit printsummary="on" haltonfailure="yes">
         <classpath>
           <path refid="classpath.test" />
           <pathelement location="${test.build.dir}"/>
@@ -44,7 +44,6 @@
             <fileset dir="${test.src.dir}" includes="**/*Test*.java" />
         </batchtest>
     </junit>
-    <fail message="test failed" if="test.failure" />
   </target>
    
   <!-- delete all class files -->


### PR DESCRIPTION
The fail task is never used, because the junit task already causes the build to fail.
